### PR TITLE
make sure GDAL do not list external files in S3 bucket

### DIFF
--- a/01_faster_loading_3.0.ipynb
+++ b/01_faster_loading_3.0.ipynb
@@ -10,14 +10,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "id": "baf1e21f-dcd9-46b7-bcbc-760ef5a13e52",
    "metadata": {},
    "outputs": [],
    "source": [
     "import xarray as xr\n",
     "import rioxarray\n",
-    "import zarr"
+    "import zarr\n",
+    "\n",
+    "import os\n",
+    "\n",
+    "# ref: https://developmentseed.org/titiler/advanced/performance_tuning/\n",
+    "os.environ[\"GDAL_DISABLE_READDIR_ON_OPEN\"] = \"EMPTY_DIR\""
    ]
   },
   {
@@ -2608,7 +2613,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.10"
+   "version": "3.9.19"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This PR adds a small GDAL environment configuration to tell GDAL to avoid listing `external` files within a bucket when opening the GeoTIFF 